### PR TITLE
Tom/11 - Implemented trigger offsets

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 var tracking = [];
 const throttle = require('lodash.throttle');
+const defaults = require('lodash.defaults');
+const defaultOptions = {top: 0, bottom: 0, left: 0, right: 0};
 
 const _onScroll = throttle(() => window.requestAnimationFrame(checkForVisibleElements), 100, {leading: false});
 
@@ -7,13 +9,13 @@ function getTracking() {
   return tracking;
 }
 
-function isVisible(elm) {
+function isVisible(elm, options) {
   let rect = elm.getBoundingClientRect();
 
-  return rect.bottom > 0 &&
-    rect.right > 0 &&
-    rect.left < (window.innerWidth || document.documentElement.clientWidth) &&
-    rect.top < (window.innerHeight || document.documentElement.clientHeight);
+  return rect.bottom - options.bottom > 0 &&
+    rect.right - options.right > 0 &&
+    rect.left + options.left < (window.innerWidth || document.documentElement.clientWidth) &&
+    rect.top + options.top < (window.innerHeight || document.documentElement.clientHeight);
 }
 
 function _handleVisible(elm, fn, options) {
@@ -22,7 +24,7 @@ function _handleVisible(elm, fn, options) {
 }
 
 function _trackNewElement(elm, fn, options) {
-  if (isVisible(elm)) {
+  if (isVisible(elm, options)) {
     return _handleVisible(elm, fn, options);
   }
   tracking.push({elm: elm, fn: fn, options: options});
@@ -30,7 +32,7 @@ function _trackNewElement(elm, fn, options) {
 
 function checkForVisibleElements() {
   tracking.slice(0).forEach((v) => {
-    if (isVisible(v.elm)) {
+    if (isVisible(v.elm, v.options)) {
       _handleVisible(v.elm, v.fn, v.options);
     }
   });
@@ -44,6 +46,8 @@ function track(elm, fn, options) {
   if (typeof fn !== 'function') {
     throw new Error('You must pass a callback function');
   }
+
+  options = defaults(options, defaultOptions);
 
   window.requestAnimationFrame(() => {
     _trackNewElement(elm, fn, options);

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "homepage": "https://github.com/samccone/scrollin",
   "dependencies": {
-    "lodash.throttle": "^3.0.2"
+    "lodash.throttle": "^3.0.2",
+    "lodash.defaults": "^4.0.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -117,3 +117,123 @@ describe('scrolling an element into the viewport', () => {
     global.window.trigger('scroll');
   });
 });
+
+describe('handling an element with top offset', () => {
+  let elm;
+
+  beforeEach(() => {
+    elm = new Element({top: 600, bottom: 700});
+  });
+
+  it('should detect the element and stop tracking', (done) => {
+    track(elm, () => {}, {top: -60});
+    elm.top = 250;
+
+    RAF(() => {
+      checkForVisibleElements();
+      assert.deepEqual(getTracking(), []);
+      done();
+    });
+  });
+
+  it('should not detect the element and keep tracking', (done) => {
+    track(elm, () => {}, {top: 60});
+    elm.top = 150;
+
+    RAF(() => {
+      checkForVisibleElements();
+      assert.equal(getTracking().length, 1);
+      done();
+    });
+  });
+});
+
+describe('handling an element with bottom offset', () => {
+  let elm;
+
+  beforeEach(() => {
+    elm = new Element({top: -200, bottom: -100});
+  });
+
+  it('should detect the element and stop tracking', (done) => {
+    track(elm, () => {}, {bottom: -60});
+    elm.bottom = -40;
+
+    RAF(() => {
+      checkForVisibleElements();
+      assert.deepEqual(getTracking(), []);
+      done();
+    });
+  });
+
+  it('should not detect the element and keep tracking', (done) => {
+    track(elm, () => {}, {bottom: 60});
+    elm.bottom = 40;
+
+    RAF(() => {
+      checkForVisibleElements();
+      assert.equal(getTracking().length, 1);
+      done();
+    });
+  });
+});
+
+describe('handling an element with left offset', () => {
+  let elm;
+
+  beforeEach(() => {
+    elm = new Element({top: 100, bottom: 200, left: 600, right: 800});
+  });
+
+  it('should detect the element and stop tracking', (done) => {
+    track(elm, () => {}, {left: -60});
+    elm.left = 540;
+
+    RAF(() => {
+      checkForVisibleElements();
+      assert.deepEqual(getTracking(), []);
+      done();
+    });
+  });
+
+  it('should not detect the element and keep tracking', (done) => {
+    track(elm, () => {}, {left: 60});
+    elm.left = 460;
+
+    RAF(() => {
+      checkForVisibleElements();
+      assert.equal(getTracking().length, 1);
+      done();
+    });
+  });
+});
+
+describe('handling an element with right offset', () => {
+  let elm;
+
+  beforeEach(() => {
+    elm = new Element({top: 100, bottom: 200, left: -200, right: -100});
+  });
+
+  it('should detect the element and stop tracking', (done) => {
+    track(elm, () => {}, {right: -60});
+    elm.right = -40;
+
+    RAF(() => {
+      checkForVisibleElements();
+      assert.deepEqual(getTracking(), []);
+      done();
+    });
+  });
+
+  it('should not detect the element and keep tracking', (done) => {
+    track(elm, () => {}, {right: 60});
+    elm.right = 40;
+
+    RAF(() => {
+      checkForVisibleElements();
+      assert.equal(getTracking().length, 1);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
There are 4 axes: top, bottom, left, right

It could have been implemented with just 2 (top, left) but this gives greater flexibility to the user if they don't want to trigger at the same spot scrolling up vs down. On the other hand that could be overkill since that use case would be very rare so we could downscale to just 2 axes but it felt incomplete to me.

In general, negative values will trigger sooner while positive values will trigger later.

There are tests for all cases: top-detected, top-undetected, left...

Added dependency on lodash.defaults to deal with options.

